### PR TITLE
Add mobile-friendly reminder tool

### DIFF
--- a/static/tools/reminder/index.html
+++ b/static/tools/reminder/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reminder</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Reminder</h1>
+        <div class="input-group">
+            <input type="text" id="reminder-text" placeholder="Reminder" />
+            <input type="datetime-local" id="reminder-time" />
+            <button id="add-btn">Add</button>
+        </div>
+        <div id="reminders" class="reminders"></div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/static/tools/reminder/script.js
+++ b/static/tools/reminder/script.js
@@ -1,0 +1,66 @@
+const textInput = document.getElementById('reminder-text');
+const timeInput = document.getElementById('reminder-time');
+const addBtn = document.getElementById('add-btn');
+const listEl = document.getElementById('reminders');
+
+let reminders = JSON.parse(localStorage.getItem('reminders') || '[]');
+
+function save() {
+    localStorage.setItem('reminders', JSON.stringify(reminders));
+}
+
+function render() {
+    listEl.innerHTML = '';
+    if (reminders.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'no-reminders';
+        empty.textContent = 'No reminders yet';
+        listEl.appendChild(empty);
+        return;
+    }
+
+    reminders.forEach((reminder, index) => {
+        const item = document.createElement('div');
+        item.className = 'reminder-item';
+
+        const info = document.createElement('div');
+        info.className = 'reminder-info';
+
+        const text = document.createElement('div');
+        text.className = 'reminder-text';
+        text.textContent = reminder.text;
+
+        const time = document.createElement('time');
+        time.className = 'reminder-time';
+        time.textContent = new Date(reminder.time).toLocaleString();
+
+        info.appendChild(text);
+        info.appendChild(time);
+
+        const del = document.createElement('button');
+        del.className = 'delete-btn';
+        del.innerHTML = '&times;';
+        del.addEventListener('click', () => {
+            reminders.splice(index, 1);
+            save();
+            render();
+        });
+
+        item.appendChild(info);
+        item.appendChild(del);
+        listEl.appendChild(item);
+    });
+}
+
+addBtn.addEventListener('click', () => {
+    const text = textInput.value.trim();
+    const time = timeInput.value;
+    if (!text || !time) return;
+    reminders.push({ text, time });
+    save();
+    textInput.value = '';
+    timeInput.value = '';
+    render();
+});
+
+render();

--- a/static/tools/reminder/style.css
+++ b/static/tools/reminder/style.css
@@ -1,0 +1,150 @@
+:root {
+    --gap: 24px;
+    --radius: 8px;
+    --theme: #1d1e20;
+    --entry: #2e2e33;
+    --primary: #ddd;
+    --secondary: #999;
+    --tertiary: #666;
+    --content: #fff;
+    --border: #333;
+    --accent: #bb86fc;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --theme: #fff;
+        --entry: #f5f5f5;
+        --primary: #333;
+        --secondary: #666;
+        --tertiary: #999;
+        --content: #000;
+        --border: #e6e6e6;
+        --accent: #5d4e8c;
+    }
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    background: var(--theme);
+    color: var(--primary);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: var(--gap);
+    font-size: 18px;
+    line-height: 1.6;
+}
+
+.container {
+    background: var(--theme);
+    max-width: 500px;
+    width: 100%;
+}
+
+h1 {
+    text-align: center;
+    color: var(--content);
+    margin-bottom: 24px;
+    font-size: 32px;
+    font-weight: 700;
+}
+
+.input-group {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.input-group input {
+    flex: 1;
+    padding: 12px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 16px;
+    background: var(--entry);
+    color: var(--primary);
+}
+
+.input-group button {
+    padding: 12px 16px;
+    border: 1px solid var(--accent);
+    background: var(--accent);
+    color: var(--theme);
+    border-radius: var(--radius);
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.reminders {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.reminder-item {
+    background: var(--entry);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.reminder-info {
+    display: flex;
+    flex-direction: column;
+}
+
+.reminder-text {
+    color: var(--primary);
+}
+
+.reminder-time {
+    color: var(--secondary);
+    font-size: 14px;
+    margin-top: 4px;
+}
+
+.delete-btn {
+    background: none;
+    border: none;
+    color: var(--tertiary);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 4px;
+}
+
+.delete-btn:hover {
+    color: var(--secondary);
+}
+
+.no-reminders {
+    text-align: center;
+    color: var(--tertiary);
+    font-size: 14px;
+    padding: 20px;
+}
+
+@media (max-width: 600px) {
+    h1 {
+        font-size: 28px;
+    }
+
+    .input-group {
+        flex-direction: column;
+    }
+
+    .input-group input,
+    .input-group button {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- Add new reminder tool with inputs for text and time and persistent list
- Style reminder tool for both dark and light themes and mobile layouts
- Implement interactive JavaScript with localStorage-backed reminders and delete support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899bf9532d483328c54d5533f193d42