### PR TITLE
Enhance planner multi-select and North Star resizing

### DIFF
--- a/static/tools/planner/style.css
+++ b/static/tools/planner/style.css
@@ -917,6 +917,7 @@ body {
     position: relative;
     padding: 16px 20px;
     min-height: 60px;
+    user-select: text;
 }
 
 .north-star-objective {
@@ -1062,6 +1063,7 @@ body {
     border-radius: 12px;
     border: 1px dashed rgba(99, 102, 241, 0.3);
     margin: 16px;
+    user-select: text;
 }
 
 .resize-handle {
@@ -1073,6 +1075,10 @@ body {
     background: rgba(99, 102, 241, 0.6);
     border-radius: 2px;
     cursor: nwse-resize;
+}
+
+.selected {
+    outline: 2px dashed #3b82f6;
 }
 
 /* Task */


### PR DESCRIPTION
## Summary
- allow dragging multiple planner objects at once with Cmd/Ctrl selection
- enable resizing North Stars in both directions with better layout
- fix child elements inside objects not being selectable

## Testing
- `./run-tests.sh --headless` *(fails: libdrm.so.2 missing after installing libatk1.0-0, libatk-bridge2.0-0, libcups2)*

------
https://chatgpt.com/codex/tasks/task_e_689a9c30d7c883329376d0096e7141eb