### PR TITLE
feat: add timeline sidebar and cross-object dependencies

### DIFF
--- a/static/tools/planner/index.html
+++ b/static/tools/planner/index.html
@@ -102,7 +102,18 @@
                 <!-- Snap preview indicator -->
                 <div id="snap-preview" class="snap-preview"></div>
             </div>
-            
+
+            <!-- Timeline sidebar -->
+            <div class="timeline-sidebar collapsed" id="timeline-sidebar">
+                <div class="timeline-header">
+                    <div class="timeline-title">Timeline</div>
+                    <button id="timeline-toggle" class="sidebar-toggle" title="Toggle timeline">
+                        <i data-lucide="chevron-left"></i>
+                    </button>
+                </div>
+                <div id="timeline-content" class="timeline-content"></div>
+            </div>
+
             <!-- Dependency mode indicator -->
             <div id="dependency-mode-indicator" class="dependency-mode-indicator">
                 <span id="dependency-mode-text">Drag from output port to input port</span>

--- a/static/tools/planner/style.css
+++ b/static/tools/planner/style.css
@@ -450,6 +450,62 @@ body {
     display: none;
 }
 
+/* Timeline sidebar */
+.timeline-sidebar {
+    width: 260px;
+    flex-shrink: 0;
+    border-left: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(8px);
+    overflow-y: auto;
+    transition: width 0.3s ease;
+    position: relative;
+}
+
+.timeline-sidebar.collapsed {
+    width: 48px;
+}
+
+.timeline-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px;
+    border-bottom: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.8);
+}
+
+.timeline-content {
+    padding: 12px;
+}
+
+.timeline-item {
+    margin-bottom: 8px;
+    font-size: 13px;
+}
+
+.timeline-item .timeline-type {
+    font-weight: 600;
+    margin-right: 4px;
+}
+
+.timeline-item .timeline-date {
+    font-size: 12px;
+    color: var(--secondary);
+    display: block;
+}
+
+.timeline-empty {
+    font-size: 13px;
+    color: var(--secondary);
+}
+
+.timeline-sidebar.collapsed .timeline-title,
+.timeline-sidebar.collapsed .timeline-content {
+    display: none;
+}
+
+
 .people-palette.collapsed .sidebar-toggle i {
     transform: rotate(180deg);
 }


### PR DESCRIPTION
## Summary
- allow dragging dependencies between tasks, epics, and north stars
- add collapsible timeline sidebar listing items by due date
- render dependencies generically across item types

## Testing
- `cd static/tools/planner && ./run-tests.sh --headless` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689abb9396508332a06abe8ce980ee6c